### PR TITLE
Fix of some errors in the memory in dictionary.c

### DIFF
--- a/pset6/dictionary.c
+++ b/pset6/dictionary.c
@@ -49,7 +49,7 @@ bool check(const char* word)
 {
     // copy the word ( because it is constant type and cannot be used)
     int l = strlen(word);
-    char *copy = malloc(l);
+    char *copy = malloc((l)+1);
     
     // copy the characters and make them lower case
     for (int i = 0; i < l; i++)


### PR DESCRIPTION
Fix of some errors in the memory in dictionary.c :
Fixed invalid reading and writing errors in the function "check", using "Valgrind".
